### PR TITLE
Fixed bug: App crashing if shortened.json does not exist

### DIFF
--- a/app.js
+++ b/app.js
@@ -22,13 +22,16 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
 
+// Create empty shortend.json if it does not already exists
+if (!fs.existsSync('shortened.json')) fs.writeFileSync('shortened.json', '{}')
+
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {
   next(createError(404));
 });
 
 // error handler
-app.use(function (err, req, res, next) {
+app.use(function (err, req, res) {
   // set locals, only providing error in development
   res.locals.message = err.message;
   res.locals.error = req.app.get('env') === 'development' ? err : {};


### PR DESCRIPTION
If the shortened.json file does not exist yet, the server will crash when trying to create or clean-up shortened-links. 
This PR fixes this issue by checking on startup if the `shortened.json` file does exist, and, if not, it creates a new one.
I also removed an unused parameter in function.